### PR TITLE
HG: Fixed debian install link and checksum.

### DIFF
--- a/debian-8.2.0-amd64.json
+++ b/debian-8.2.0-amd64.json
@@ -25,8 +25,8 @@
 
 		"output_directory": "builds",
 
-		"iso_url": "http://mirror.internode.on.net/pub/debian-cd/current/amd64/iso-cd/debian-8.2.0-amd64-netinst.iso",
-		"iso_checksum": "a41801dcc0e37bce2406e18b334f99ae366d6fde",
+		"iso_url": "http://mirror.internode.on.net/pub/debian-cd/current/amd64/iso-cd/debian-8.3.0-amd64-netinst.iso",
+		"iso_checksum": "bbc286b59fcbabd0a1cab7fb083d98ae133ff909",
 		"iso_checksum_type": "sha1",
 
 		"http_directory": "installconfig",


### PR DESCRIPTION
Hi ! I wanted to check your tool out and the debian link was too old and the checksum did not match so here is the new one !
